### PR TITLE
Use SLF4J logging interface instead of System.out calls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,40 @@
+# Eclipse
+.classpath
+.project
+.settings/
+
+# Intellij
+.idea/
+*.iml
+*.iws
+
+# Mac
+.DS_Store
+
+# Maven
+log/
+target/
+
+# Xcode
+#
+# gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
+
+## Build generated
+build/
+DerivedData/
+
+## Various settings
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+xcuserdata/
+
+## Other
+*.moved-aside
+*.xccheckout
+*.xcscmblueprint

--- a/README.md
+++ b/README.md
@@ -246,6 +246,9 @@ Using reflection to search for methods with either two or three parameters, wher
 
 First port of call is to look at the information printed to the console on startup. If you see `Reflections URLs: []` you might need to check your `restolino.packageprefix` setting - I've made this mistake a couple of times. If nothing is happening when you update a class, check the values of classesReloadable and classesInClasspath. It's not possible to reload classes that are on the JVM classpath at startup.
 
+#### How can I enable logging?
+
+Restolino uses the SLF4J interface for logging. Please refer to the [SLF4J documentation](http://www.slf4j.org/) for further information on enabling its output.
 
 #### Is it really this cool?
 

--- a/pom.xml
+++ b/pom.xml
@@ -106,6 +106,14 @@
             <version>0.9.9</version>
         </dependency>
 
+        <!-- Logging -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.5</version>
+            <scope>compile</scope>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/src/main/java/com/github/davidcarboni/restolino/Configuration.java
+++ b/src/main/java/com/github/davidcarboni/restolino/Configuration.java
@@ -2,12 +2,15 @@ package com.github.davidcarboni.restolino;
 
 import org.apache.commons.lang3.StringUtils;
 import org.reflections.Reflections;
+import org.slf4j.Logger;
 
 import java.io.IOException;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.file.FileSystems;
 import java.nio.file.Path;
+
+import static org.slf4j.LoggerFactory.getLogger;
 
 /**
  * Determines the correct configuration, based on environment variables, system
@@ -17,6 +20,7 @@ import java.nio.file.Path;
  */
 public class Configuration {
 
+    private static final Logger log = getLogger(Configuration.class);
     public static final String PORT = "PORT";
     public static final String CLASSES = "restolino.classes";
     public static final String PACKAGE_PREFIX = "restolino.packageprefix";
@@ -168,9 +172,9 @@ public class Configuration {
         if (StringUtils.isNotBlank(port)) {
             try {
                 this.port = Integer.parseInt(port);
-                System.out.println(this.getClass().getSimpleName() + ": Using port " + this.port + " (specify a PORT environment variable to change it)");
+                log.info(this.getClass().getSimpleName() + ": Using port " + this.port + " (specify a PORT environment variable to change it)");
             } catch (NumberFormatException e) {
-                System.out.println(this.getClass().getSimpleName() + ": Unable to parse server PORT variable (" + port + ") using port " + port);
+                log.info(this.getClass().getSimpleName() + ": Unable to parse server PORT variable (" + port + ") using port " + port);
             }
         }
     }
@@ -359,7 +363,7 @@ public class Configuration {
         } else {
             message = "No static files will be served.";
         }
-        System.out.println(this.getClass().getSimpleName() + ": Files: " + message);
+        log.info(this.getClass().getSimpleName() + ": Files: " + message);
     }
 
     /**
@@ -369,7 +373,7 @@ public class Configuration {
 
         // Warning about a classes folder present in the classpath:
         if (classesInClasspath != null) {
-            System.out.println(this.getClass().getSimpleName() + ": WARNING: Dynamic class reloading is disabled because a classes URL is present in the classpath. P"
+            log.info(this.getClass().getSimpleName() + ": WARNING: Dynamic class reloading is disabled because a classes URL is present in the classpath. P"
                     + "lease launch without including your classes directory: " + classesInClasspath);
         }
 
@@ -384,7 +388,7 @@ public class Configuration {
         } else {
             message = "Classes will not be dynamically reloaded.";
         }
-        System.out.println(this.getClass().getSimpleName() + ": Classes: " + message);
+        log.info(this.getClass().getSimpleName() + ": Classes: " + message);
     }
 
     /**

--- a/src/main/java/com/github/davidcarboni/restolino/Main.java
+++ b/src/main/java/com/github/davidcarboni/restolino/Main.java
@@ -8,6 +8,9 @@ import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.handler.StatisticsHandler;
 import org.eclipse.jetty.server.handler.gzip.GzipHandler;
+import org.slf4j.Logger;
+
+import static org.slf4j.LoggerFactory.getLogger;
 
 /**
  * This class launches an embedded Jetty server. This is the entry point to your
@@ -15,6 +18,8 @@ import org.eclipse.jetty.server.handler.gzip.GzipHandler;
  * can set it as the <code>Main-Class</code> in your JAR manifest.
  */
 public class Main {
+
+    private static final Logger log = getLogger(Main.class);
 
     public static Configuration configuration;
     public static Server server;
@@ -63,12 +68,12 @@ public class Main {
                 @Override
                 public void run() {
                     try {
-                        System.out.println("Initiating graceful shutdown...");
+                        log.info("Initiating graceful shutdown...");
                         //server.getHandler().stop();
                         server.stop();
-                        System.out.println("Shutdown completed gracefully.");
+                        log.info("Shutdown completed gracefully.");
                     } catch (Exception e) {
-                        System.out.println("Shutdown error:");
+                        log.info("Shutdown error:");
                         e.printStackTrace();
                     }
                 }
@@ -77,7 +82,7 @@ public class Main {
             // And we're good to go
             server.start();
             System.out.println(configuration);
-            System.out.println("\nCompleted startup process.");
+            log.info("\nCompleted startup process.");
             server.join();
 
         } finally {

--- a/src/main/java/com/github/davidcarboni/restolino/api/ApiConfiguration.java
+++ b/src/main/java/com/github/davidcarboni/restolino/api/ApiConfiguration.java
@@ -484,7 +484,7 @@ public class ApiConfiguration {
     private static Object invoke(HttpServletRequest request, HttpServletResponse response, Object handler, Method method, Class<?> requestMessage) throws Exception {
         Object result = null;
 
-        log.info("Invoking method " + method.getName() + " on " + handler.getClass().getSimpleName());
+        log.info("Invoking method {} on {}", method.getName(), handler.getClass().getSimpleName());
         // + " for request message "
         // + requestMessage);
         if (requestMessage != null) {

--- a/src/main/java/com/github/davidcarboni/restolino/handlers/DefaultServerErrorHandler.java
+++ b/src/main/java/com/github/davidcarboni/restolino/handlers/DefaultServerErrorHandler.java
@@ -2,12 +2,14 @@ package com.github.davidcarboni.restolino.handlers;
 
 import com.github.davidcarboni.restolino.api.RequestHandler;
 import com.github.davidcarboni.restolino.framework.ServerError;
-import com.github.davidcarboni.restolino.json.Serialiser;
 import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.slf4j.Logger;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
+
+import static org.slf4j.LoggerFactory.getLogger;
 
 /**
  * Default {@link ServerError} handler.
@@ -16,10 +18,12 @@ import java.io.IOException;
  */
 public class DefaultServerErrorHandler implements ServerError {
 
+    private static final Logger log = getLogger(DefaultServerErrorHandler.class);
+
     @Override
     public String handle(HttpServletRequest request, HttpServletResponse response, RequestHandler requestHandler, Throwable t) throws IOException {
         String stackTrace = ExceptionUtils.getStackTrace(t);
-        System.out.println(stackTrace);
+        log.info(stackTrace);
         return stackTrace;
     }
 }

--- a/src/main/java/com/github/davidcarboni/restolino/helpers/QueryString.java
+++ b/src/main/java/com/github/davidcarboni/restolino/helpers/QueryString.java
@@ -1,23 +1,20 @@
 package com.github.davidcarboni.restolino.helpers;
 
-import com.google.common.net.UrlEscapers;
 import org.apache.commons.lang3.StringUtils;
-import org.eclipse.jetty.util.UrlEncoded;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.Map;
 import java.util.List;
+import java.util.Map;
 
 /**
  * This class enables you to work with a URL query string.
- * <p/>
+ * <p>
  * Whilst technically a query string can contain multiple values for a single
  * parameter name, in practice this rarely happens so, for expedience, this
  * class is a Map.
@@ -49,8 +46,8 @@ public class QueryString extends HashMap<String, String> {
                         String decodedKey;
                         String decodedValue;
                         try {
-                             decodedKey = URLDecoder.decode(key, StandardCharsets.UTF_8.name());
-                             decodedValue = URLDecoder.decode(value, StandardCharsets.UTF_8.name());
+                            decodedKey = URLDecoder.decode(key, StandardCharsets.UTF_8.name());
+                            decodedValue = URLDecoder.decode(value, StandardCharsets.UTF_8.name());
                         } catch (UnsupportedEncodingException e) {
                             throw new IllegalArgumentException("URL does not appear to be UTF8 encoded", e);
                         }

--- a/src/main/java/com/github/davidcarboni/restolino/jetty/ApiHandler.java
+++ b/src/main/java/com/github/davidcarboni/restolino/jetty/ApiHandler.java
@@ -6,21 +6,25 @@ import org.apache.commons.lang3.StringUtils;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.handler.AbstractHandler;
 import org.reflections.Reflections;
+import org.slf4j.Logger;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
+import static org.slf4j.LoggerFactory.getLogger;
+
 public class ApiHandler extends AbstractHandler {
 
+    private static final Logger log = getLogger(ApiHandler.class);
     static final String KEY_CLASSES = "restolino.classes";
 
     public static volatile ApiConfiguration api;
 
     public ApiHandler() {
         if (Main.configuration.classesInClasspath != null) {
-            System.out.println("Classes are included in the classpath. No reloading will be configured (" + Main.configuration.classesInClasspath + ")");
+            log.info("Classes are included in the classpath. No reloading will be configured (" + Main.configuration.classesInClasspath + ")");
         }
     }
 

--- a/src/main/java/com/github/davidcarboni/restolino/jetty/MainHandler.java
+++ b/src/main/java/com/github/davidcarboni/restolino/jetty/MainHandler.java
@@ -14,6 +14,7 @@ import org.eclipse.jetty.server.handler.HandlerCollection;
 import org.eclipse.jetty.server.handler.ResourceHandler;
 import org.eclipse.jetty.util.resource.Resource;
 import org.reflections.Reflections;
+import org.slf4j.Logger;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
@@ -25,7 +26,11 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 
+import static org.slf4j.LoggerFactory.getLogger;
+
 public class MainHandler extends HandlerCollection {
+
+    private static final Logger log = getLogger(MainHandler.class);
 
     /**
      * Just in case you need to change it.
@@ -78,9 +83,9 @@ public class MainHandler extends HandlerCollection {
 
             this.filesHandler = filesHandler;
 
-            System.out.println("Set up static file handler for URL: " + url);
+            log.info("Set up static file handler for URL: " + url);
         } else {
-            System.out.println("No static file handler configured.");
+            log.info("No static file handler configured.");
         }
     }
 
@@ -181,7 +186,7 @@ public class MainHandler extends HandlerCollection {
             try {
                 result.add(filterClass.newInstance());
             } catch (InstantiationException | IllegalAccessException e) {
-                System.out.println("Error instantiating filter class " + filterClass.getName());
+                log.info("Error instantiating filter class " + filterClass.getName());
                 e.printStackTrace();
             }
         }
@@ -196,7 +201,7 @@ public class MainHandler extends HandlerCollection {
             try {
                 startups.add(startupClass.newInstance());
             } catch (InstantiationException | IllegalAccessException e) {
-                System.out.println("Error instantiating startup class " + startupClass.getName());
+                log.info("Error instantiating startup class " + startupClass.getName());
                 e.printStackTrace();
             }
         }

--- a/src/main/java/com/github/davidcarboni/restolino/reload/ClassFinder.java
+++ b/src/main/java/com/github/davidcarboni/restolino/reload/ClassFinder.java
@@ -5,12 +5,16 @@ import org.apache.commons.lang3.StringUtils;
 import org.reflections.Reflections;
 import org.reflections.util.ClasspathHelper;
 import org.reflections.util.ConfigurationBuilder;
+import org.slf4j.Logger;
 
 import java.net.URL;
 import java.net.URLClassLoader;
 
+import static org.slf4j.LoggerFactory.getLogger;
+
 public class ClassFinder {
 
+    private static final Logger log = getLogger(ClassFinder.class);
     private static ClassLoader classLoader;
 
     public static Reflections newReflections() {
@@ -44,9 +48,9 @@ public class ClassFinder {
         }
         Reflections reflections = new Reflections(configurationBuilder);
 
-        System.out.println("Reflections URLs: " + reflections.getConfiguration().getUrls());
+        log.info("Reflections URLs: " + reflections.getConfiguration().getUrls());
         if (Main.configuration.classesReloadable && reflections.getConfiguration().getUrls().size() == 0 && StringUtils.isNotEmpty(Main.configuration.packagePrefix)) {
-            System.out.println("It looks like no reloadable classes were found. Is '" + Main.configuration.packagePrefix + "' the correct package prefix for your app?");
+            log.info("It looks like no reloadable classes were found. Is '" + Main.configuration.packagePrefix + "' the correct package prefix for your app?");
         }
         return reflections;
     }

--- a/src/main/java/com/github/davidcarboni/restolino/reload/ClassReloader.java
+++ b/src/main/java/com/github/davidcarboni/restolino/reload/ClassReloader.java
@@ -3,14 +3,18 @@ package com.github.davidcarboni.restolino.reload;
 import com.github.davidcarboni.restolino.Main;
 import com.github.davidcarboni.restolino.jetty.ApiHandler;
 import org.reflections.Reflections;
+import org.slf4j.Logger;
 
 import java.io.IOException;
 import java.nio.file.FileSystems;
 import java.nio.file.Path;
 import java.nio.file.WatchService;
 
+import static org.slf4j.LoggerFactory.getLogger;
+
 public class ClassReloader implements Runnable {
 
+    private static final Logger log = getLogger(ClassReloader.class);
     static ClassReloader classMonitor;
     static WatchService watcher;
     String path;
@@ -99,7 +103,7 @@ public class ClassReloader implements Runnable {
     public static void shutdown() throws IOException {
         if (watcher != null) {
             synchronized (watcher) {
-                System.out.println("Closing filesystem monitor.");
+                log.info("Closing filesystem monitor.");
                 watcher.close();
                 watcher = null;
             }

--- a/src/main/java/com/github/davidcarboni/restolino/reload/Scanner.java
+++ b/src/main/java/com/github/davidcarboni/restolino/reload/Scanner.java
@@ -1,5 +1,7 @@
 package com.github.davidcarboni.restolino.reload;
 
+import org.slf4j.Logger;
+
 import java.io.IOException;
 import java.nio.file.*;
 import java.nio.file.attribute.BasicFileAttributes;
@@ -7,8 +9,11 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 import static java.nio.file.FileVisitResult.CONTINUE;
+import static org.slf4j.LoggerFactory.getLogger;
 
 public class Scanner implements Runnable {
+
+    private static final Logger log = getLogger(Scanner.class);
 
     static Path root;
     static Map<Path, Monitor> monitors = new ConcurrentHashMap<>();
@@ -24,7 +29,7 @@ public class Scanner implements Runnable {
         Scanner.watcher = watcher;
         Scanner.root = root;
 
-        System.out.println("Monitoring changes under " + root);
+        log.info("Monitoring changes under " + root);
         Thread t = new Thread(new Scanner(), "Directory scanner");
         t.setDaemon(true);
         t.start();
@@ -40,10 +45,10 @@ public class Scanner implements Runnable {
 
             // Scan for directories:
             try {
-                System.out.println("Scanning for directories under " + root);
+                log.info("Scanning for directories under " + root);
                 Files.walkFileTree(root, new Visitor());
             } catch (IOException e) {
-                System.out.println("Error in scanning for directories to monitor:");
+                log.info("Error in scanning for directories to monitor:");
                 e.printStackTrace();
             }
 
@@ -52,7 +57,7 @@ public class Scanner implements Runnable {
                 try {
                     Scanner.class.wait();
                 } catch (InterruptedException e) {
-                    System.out.println("Scanner interrupted:");
+                    log.info("Scanner interrupted:");
                     e.printStackTrace();
                 }
             }
@@ -74,7 +79,7 @@ public class Scanner implements Runnable {
             if (!monitors.containsKey(path)) {
                 // Not too worried about race conditions here,
                 // so long as one ends up in the Map.
-                System.out.println("Adding monitor for path " + path);
+                log.info("Adding monitor for path " + path);
                 monitors.put(path, new Monitor(path, watcher));
             }
             return CONTINUE;


### PR DESCRIPTION
Using the SLF4J API for logging gives Restolino users fine grained control over logging with whatever logging library they are using. 
